### PR TITLE
introduce prompt() function

### DIFF
--- a/problems/using_npm_packages/problem.txt
+++ b/problems/using_npm_packages/problem.txt
@@ -11,6 +11,9 @@ just like you would do in node.js!
 `require('uniq')` returns a `uniq(xs)` function that removes duplicate
 items from an array input `xs`.
 
+You will also need `prompt()`, a built in function available to browsers that
+asks the user to enter some text, and returns a string.
+
 For this level, use `prompt()` to fetch a string. Split the string that
 `prompt()` returns by commas (`str.split(',')` returns a separated array of
 strings) and run this array through `uniq()` to discard repeated items.


### PR DESCRIPTION
There's been [some confusion](https://github.com/substack/browserify-adventure/issues/12) about the `window.prompt()` function and where it comes from. It's mentioned in passing for the first time in 'Using npm packages' but not explained that it's NOT an npm module and is in fact a browser built-in that returns a string synchronously. This edit makes the function and its usage explicit.