### PR TITLE
instruct users to copy wake.txt locally

### DIFF
--- a/problems/writing_transforms/problem.txt
+++ b/problems/writing_transforms/problem.txt
@@ -1,13 +1,17 @@
 Building upon the previous "using transforms" second, write a custom
 browserify transform so that in main.js you can simply do:
 
-  var txt = require('$WAKE_FILE');
+  var txt = require('./wake.txt');
   console.log(txt);
 
 and the `txt` output will be formatted with the proper line-numbering as
 from the previous level: printf("%3d %s", lineNum, line) every 5th line
 line numbers starting from zero and four leading spaces on the other
 lines.
+
+You'll first need to copy wake.txt to your local directory:
+
+  cp $WAKE_FILE .
 
 You will need to factor out your formatting code to be a node transform
 stream, which you can learn more about in the stream-adventure nodeschool


### PR DESCRIPTION
Sorry @substack -- another PR here. :)

I came across this issue when answering [a nodeschool question](https://github.com/nodeschool/discussions/issues/1739), as have [others](https://github.com/substack/browserify-adventure/issues/20).

It seems this is an issue where files inside non-top-level `node_modules/` directories [don't get processed by normal transforms](https://github.com/substack/node-browserify/issues/515).

This is a reasonable design decision, but it makes the instructions for "Writing Transforms" not work. This is a small edit to get this working again.