### PR TITLE
Use split2 in "Writing Transforms".

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "through2": "~0.5.1",
     "ever": "~0.0.3",
     "colornames": "~0.0.2"
+    "split2": "^2.1.0"
   },
   "devDependencies": {
     "brfs": "^1.1.2",

--- a/problems/writing_transforms/problem.txt
+++ b/problems/writing_transforms/problem.txt
@@ -41,7 +41,7 @@ output that looks like:
 
 You can either buffer up in the input with the `concat-stream` module and
 run your previous solution to the previous "using transforms" level or if
-you are feeling adventurous, you can string together the `split`,
+you are feeling adventurous, you can string together `split2`,
 `quote-stream`, and `through2` modules with `stream-combiner2` to build a
 transform that processes the files in-place.
 

--- a/solutions/writing_transforms/tr.js
+++ b/solutions/writing_transforms/tr.js
@@ -1,5 +1,5 @@
 var through = require('through2');
-var split = require('split');
+var split = require('split2');
 var sprintf = require('sprintf');
 var quote = require('quote-stream');
 var combine = require('stream-combiner2');


### PR DESCRIPTION
Addresses https://github.com/substack/browserify-adventure/issues/25. I noticed that `split` doesn't work anymore in a `stream-comnbiner2` as of 1.1.0. The new streams3 wrapping code causes `split` to no longer function in a browserify transform.

I cannot reproduce this using solely `stream-combiner2` nor with `split`, so there seems to be some kind of more complicated interplay with how `split`/`stream-combiner2`/`browserify` interact -- the pipeline doesn't flow.

Workarounds include a) using `split2`, b) using `pumpify` instead of `stream-combiner2`, or interestingly c) placing a passthrough `through2` in front of `split` in the combiner. This PR performs `s/split/split2` in the problem "Writing Transforms".
